### PR TITLE
Fix cropping when one dimension equals corresponding image dimension

### DIFF
--- a/salience.go
+++ b/salience.go
@@ -39,8 +39,8 @@ func Crop(img image.Image, cropWidth, cropHeight int) image.Image {
 	}
 	bestSection := Section{0, 0, 0.0}
 
-	for x = 0; x < imageWidth-cropWidth; x += sliceStep {
-		for y = 0; y < imageHeight-cropHeight; y += sliceStep {
+	for x = 0; x <= imageWidth-cropWidth; x += sliceStep {
+		for y = 0; y <= imageHeight-cropHeight; y += sliceStep {
 			e := entropy(img, image.Rect(x, y, x+cropWidth, y+cropHeight))
 
 			if e > bestSection.e {

--- a/salience.go
+++ b/salience.go
@@ -9,6 +9,7 @@ package salience
 import (
 	"image"
 	"image/color"
+	"image/draw"
 	"math"
 )
 
@@ -49,17 +50,12 @@ func Crop(img image.Image, cropWidth, cropHeight int) image.Image {
 			}
 		}
 	}
-
 	return crop(img, image.Rect(bestSection.x, bestSection.y, bestSection.x+cropWidth, bestSection.y+cropHeight))
 }
 
 func crop(img image.Image, r image.Rectangle) image.Image {
-	cropped := image.NewRGBA(r)
-	for x := r.Min.X; x < r.Max.X; x++ {
-		for y := r.Min.Y; y < r.Max.Y; y++ {
-			cropped.Set(x, y, img.At(x, y))
-		}
-	}
+	cropped := image.NewRGBA(image.Rect(0, 0, r.Dx(), r.Dy()))
+	draw.Draw(cropped, cropped.Bounds(), img, r.Min, draw.Src)
 	return cropped
 }
 


### PR DESCRIPTION
I experimented with your lib and found out, that when I tried to get the best square top of whole image (eg 1600x1200 cropping to 1200x1200):

``` go
for y = 0; y < imageHeight-cropHeight; y += sliceStep
// imageHeight=1200, cropHeight=1200
// becomes
for y = 0; y < 0; y += sliceStep
```

and no iteration happen (though `for x...` loop have some iteration)

And it always crops at (0, 0)
